### PR TITLE
Decrease cpu usage with usleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 LDFLAGS = -lSDL2 -lX11
-CC = gcc -std=c99
+CC = gcc -std=gnu99
 CFLAGS = -O2 -Wall -Wextra -Wpedantic
 BIN = paperview
 SRC = main.c

--- a/main.c
+++ b/main.c
@@ -1,6 +1,8 @@
 #include <SDL2/SDL.h>
 #include <X11/Xlib.h>
 #include <dirent.h>
+#include <unistd.h>
+
 
 typedef struct
 {
@@ -130,14 +132,16 @@ int main(int argc, char* argv[])
     Video video = Setup();
     Paths paths = Populate(base);
     Textures textures = Cache(&paths, video.renderer);
-    for(int32_t cycles = 0; /* TRUE */; cycles++)
+
+    int32_t framerate = 1000000 / speed;
+    for(uint32_t cycles = 0; /* TRUE */; cycles++)
     {
-        const int32_t index = cycles / speed;
-        const int32_t frame = index % textures.size;
+        const int32_t frame = cycles % textures.size;
         SDL_RenderCopy(video.renderer, textures.texture[frame], NULL, NULL);
         SDL_RenderPresent(video.renderer);
         SDL_Event event;
         SDL_PollEvent(&event);
+        usleep(framerate);
         if(event.type == SDL_QUIT)
             break;
     }


### PR DESCRIPTION
Change second argument to the frame rate
Fix UB (int32_t overflow)
Add gnu99 to access usleep.